### PR TITLE
GUARD-2893 (Access) ShippingDetail-RecordNumber-Empty-Bug

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -47,11 +47,10 @@ $src_dir = "$BuildRoot\src"
 $solution_file = "$src_dir\$($project_name).sln"
 	
 # Use MSBuild.
-#use Framework\v4.0.30319 MSBuild
-Set-Alias MSBuild14 (Join-Path -Path (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\14.0").MSBuildToolsPath -ChildPath "MSBuild.exe")
+Set-Alias MSBuild16 (Join-Path -Path (Get-VSSetupInstance | Where-Object {$_.DisplayName -eq 'Visual Studio Professional 2019'} | select InstallationPath | Select-Object -first 1).InstallationPath -ChildPath "MSBuild\Current\Bin\MSBuild.exe")
 
 task Clean { 
-	exec { MSBuild14 "$solution_file" /t:Clean /p:Configuration=Release /p:VisualStudioVersion="14.0" /v:quiet } 
+	exec { MSBuild16 "$solution_file" /t:Clean /p:Configuration=Release /p:Platform="Any CPU" /v:quiet } 
 	Remove-Item -force -recurse $build_dir -ErrorAction SilentlyContinue | Out-Null
 }
 
@@ -62,7 +61,7 @@ task Init Clean, {
 }
 
 task Build {
-	exec { MSBuild14 "$solution_file" /t:Build /p:Configuration=Release /p:VisualStudioVersion="14.0" /v:minimal /p:OutDir="$build_artifacts_dir\" }
+	exec { MSBuild16 "$solution_file" /t:Build /p:Configuration=Release /p:Platform="Any CPU" /v:minimal /p:OutDir="$build_artifacts_dir\" }
 }
 
 task Package  {

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ _ReSharper*/
 [Tt]est[Rr]esult*
 *.ReSharper
 *.docstates
+
+# JetBrains Rider
+.idea/
 *.csv
 #Ignore common build files
 build

--- a/src/EbayAccess/Misc/Extensions.cs
+++ b/src/EbayAccess/Misc/Extensions.cs
@@ -117,14 +117,17 @@ namespace EbayAccess.Misc
 		{
 			try
 			{
-				return int.Parse( source, CultureInfo.InvariantCulture );
+				if ( !string.IsNullOrWhiteSpace( source ) )
+				{
+					return int.Parse( source, CultureInfo.InvariantCulture );
+				}
 			}
 			catch( Exception )
 			{
 				if( throwException )
 					throw;
 			}
-
+			
 			return default( int );
 		}
 

--- a/src/EbayAccess/Models/GetOrdersResponse/OrderExtended.cs
+++ b/src/EbayAccess/Models/GetOrdersResponse/OrderExtended.cs
@@ -27,8 +27,10 @@ namespace EbayAccess.Models.GetOrdersResponse
 			string result = null;
 			if( useSellingManagerRecordNumberInstead )
 			{
-				if( sourceOrder.ShippingDetails != null )
+				if( sourceOrder.ShippingDetails != null && sourceOrder.ShippingDetails.SellingManagerSalesRecordNumber != default( int ) )
+				{
 					result = sourceOrder.ShippingDetails.SellingManagerSalesRecordNumber.ToString();
+				}
 			}
 			else
 				result = sourceOrder.OrderId;

--- a/src/EbayAccess/Services/Parsers/EbayGetOrdersResponseParser.cs
+++ b/src/EbayAccess/Services/Parsers/EbayGetOrdersResponseParser.cs
@@ -260,9 +260,10 @@ namespace EbayAccess.Services.Parsers
 			var shippingDetails = x.Element( ns + "ShippingDetails" );
 			if ( shippingDetails != null )
 			{
+				var salesRecordNumberValue = GetElementValue( x, ns, "ShippingDetails", "SellingManagerSalesRecordNumber" );
 				var result = new ShippingDetails
 				{
-					SellingManagerSalesRecordNumber = GetElementValue( x, ns, "ShippingDetails", "SellingManagerSalesRecordNumber" ).ToIntOrDefault(),
+					SellingManagerSalesRecordNumber = salesRecordNumberValue.ToIntOrDefault(),
 					GetItFast = GetElementValue( x, ns, "ShippingDetails", "GetItFast" ).ToBoolNullable()
 				};
 

--- a/src/EbayAccessTests/EbayAccessTests.csproj
+++ b/src/EbayAccessTests/EbayAccessTests.csproj
@@ -64,11 +64,12 @@
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="EbayServiceTest.cs" />
-    <Compile Include="Misc\Extensions.cs" />
+    <Compile Include="Misc\ExtensionsTests.cs" />
     <Compile Include="Misc\LoggerTests.cs" />
     <Compile Include="Misc\TimeoutTests.cs" />
     <Compile Include="Models\BaseResponse\EbayBaseResponseTests.cs" />
     <Compile Include="Models\CredentialsAndConfig\EbayConfigTest.cs" />
+    <Compile Include="Models\GetOrdersResponse\OrderExtendedTests.cs" />
     <Compile Include="Models\GetSellerListResponse\ItemExtendedTest.cs" />
     <Compile Include="Models\GetSellerListResponse\ProductTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -144,6 +145,9 @@
     <Content Include="Files\GetOrdersResponse\EbayServiceGetSaleRecordsNumbersResponseWithDatabaseError.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
+    <Content Include="Files\GetOrdersResponse\EbayServiceGetOrdersResponseWithoutSellingManagerSalesRecordNumber.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Files\GetSellerListCustomProductResponse\EbayServiceGetSellerListCustomProductResponse.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -164,7 +168,6 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/EbayAccessTests/Files/GetOrdersResponse/EbayServiceGetOrdersResponseWithoutSellingManagerSalesRecordNumber.xml
+++ b/src/EbayAccessTests/Files/GetOrdersResponse/EbayServiceGetOrdersResponseWithoutSellingManagerSalesRecordNumber.xml
@@ -1,0 +1,164 @@
+<GetOrdersResponse xmlns="urn:ebay:apis:eBLBaseComponents">
+    <Timestamp>2023-04-15T14:20:44.804Z</Timestamp>
+    <Ack>Success</Ack>
+    <Version>1303</Version>
+    <Build>E1289_CORE_APIXO_19220561_R1</Build>
+    <PaginationResult>
+        <TotalNumberOfPages>1</TotalNumberOfPages>
+        <TotalNumberOfEntries>33</TotalNumberOfEntries>
+    </PaginationResult>
+    <HasMoreOrders>false</HasMoreOrders>
+    <OrderArray>
+        <Order>
+            <OrderID>26-07596-00721</OrderID>
+            <OrderStatus>Cancelled</OrderStatus>
+            <AdjustmentAmount currencyID="USD">-609.98</AdjustmentAmount>
+            <AmountPaid currencyID="USD">0.0</AmountPaid>
+            <AmountSaved currencyID="USD">0.0</AmountSaved>
+            <CheckoutStatus>
+                <eBayPaymentStatus>NoPaymentFailure</eBayPaymentStatus>
+                <LastModifiedTime>2021-09-13T15:49:55.803Z</LastModifiedTime>
+                <PaymentMethod>CreditCard</PaymentMethod>
+                <Status>Complete</Status>
+                <IntegratedMerchantCreditCardEnabled>false</IntegratedMerchantCreditCardEnabled>
+                <PaymentInstrument>BML</PaymentInstrument>
+            </CheckoutStatus>
+            <ShippingDetails>
+                <SalesTax>
+                    <ShippingIncludedInTax>false</ShippingIncludedInTax>
+                </SalesTax>
+                <ShippingServiceOptions>
+                    <ShippingService>USPSFirstClass</ShippingService>
+                    <ShippingServicePriority>1</ShippingServicePriority>
+                    <ExpeditedService>false</ExpeditedService>
+                </ShippingServiceOptions>
+                <TaxTable>
+                    <TaxJurisdiction>
+                        <SalesTaxPercent>8.25</SalesTaxPercent>
+                        <ShippingIncludedInTax>false</ShippingIncludedInTax>
+                    </TaxJurisdiction>
+                </TaxTable>
+                <GetItFast>false</GetItFast>
+            </ShippingDetails>
+            <CreatedTime>2021-09-13T15:49:55.803Z</CreatedTime>
+            <ShippingAddress>
+                <Name>***</Name>
+                <Street1>***</Street1>
+                <Street2>***</Street2>
+                <CityName>***</CityName>
+                <StateOrProvince>***</StateOrProvince>
+                <Country>***</Country>
+                <CountryName>***</CountryName>
+                <Phone>***</Phone>
+                <PostalCode>97217-8190</PostalCode>
+                <AddressID>10001717046131</AddressID>
+                <AddressOwner>eBay</AddressOwner>
+            </ShippingAddress>
+            <ShippingServiceSelected>
+                <ShippingService>USPSPriority</ShippingService>
+                <ShippingServiceCost currencyID="USD">5.93</ShippingServiceCost>
+            </ShippingServiceSelected>
+            <Subtotal currencyID="USD">316.18</Subtotal>
+            <Total currencyID="USD">0.0</Total>
+            <eBayCollectAndRemitTax>false</eBayCollectAndRemitTax>
+            <TransactionArray>
+                <Transaction>
+                    <Buyer>
+                        <Email>***</Email>
+                        <VATStatus>NoVATTax</VATStatus>
+                        <UserFirstName>***</UserFirstName>
+                        <UserLastName>***</UserLastName>
+                    </Buyer>
+                    <ShippingDetails>
+                        <SalesTax>
+                            <SalesTaxPercent>0.0</SalesTaxPercent>
+                        </SalesTax>
+                    </ShippingDetails>
+                    <CreatedDate>2021-11-07T01:45:06.803Z</CreatedDate>
+                    <Item>
+                        <ItemID>124813779710</ItemID>
+                        <Site>US</Site>
+                        <Title>Sig Sauer P320 Custom Works FCU Factory OEM Trigger Parts Kit Lower</Title>
+                        <SKU>FCU-P320</SKU>
+                        <ConditionID>1000</ConditionID>
+                        <ConditionDisplayName>New</ConditionDisplayName>
+                    </Item>
+                    <QuantityPurchased>1</QuantityPurchased>
+                    <Status>
+                        <PaymentHoldStatus>None</PaymentHoldStatus>
+                        <InquiryStatus>NotApplicable</InquiryStatus>
+                        <ReturnStatus>NotApplicable</ReturnStatus>
+                    </Status>
+                    <TransactionID>2467341912002</TransactionID>
+                    <TransactionPrice currencyID="USD">316.18</TransactionPrice>
+                    <eBayCollectAndRemitTax>false</eBayCollectAndRemitTax>
+                    <ShippingServiceSelected>
+                        <ShippingService></ShippingService>
+                        <ShippingPackageInfo>
+                            <EstimatedDeliveryTimeMin>2021-11-13T08:00:00.803Z</EstimatedDeliveryTimeMin>
+                            <EstimatedDeliveryTimeMax>2021-11-13T08:00:00.803Z</EstimatedDeliveryTimeMax>
+                            <HandleByTime>2021-11-09T05:59:59.803Z</HandleByTime>
+                            <MinNativeEstimatedDeliveryTime>2021-11-10T08:00:00.803Z</MinNativeEstimatedDeliveryTime>
+                            <MaxNativeEstimatedDeliveryTime>2021-11-15T08:00:00.803Z</MaxNativeEstimatedDeliveryTime>
+                        </ShippingPackageInfo>
+                    </ShippingServiceSelected>
+                    <TransactionSiteID>US</TransactionSiteID>
+                    <Platform>eBay</Platform>
+                    <Taxes>
+                        <TotalTaxAmount currencyID="USD">0.0</TotalTaxAmount>
+                        <TaxDetails>
+                            <Imposition>SalesTax</Imposition>
+                            <TaxDescription>SalesTax</TaxDescription>
+                            <TaxAmount currencyID="USD">0.0</TaxAmount>
+                            <TaxOnSubtotalAmount currencyID="USD">0.0</TaxOnSubtotalAmount>
+                            <TaxOnShippingAmount currencyID="USD">0.0</TaxOnShippingAmount>
+                            <TaxOnHandlingAmount currencyID="USD">0.0</TaxOnHandlingAmount>
+                        </TaxDetails>
+                    </Taxes>
+                    <ActualShippingCost currencyID="USD">5.93</ActualShippingCost>
+                    <ActualHandlingCost currencyID="USD">0.0</ActualHandlingCost>
+                    <OrderLineItemID>124813779710-2467341912002</OrderLineItemID>
+                    <InventoryReservationID>2467341912002</InventoryReservationID>
+                    <ExtendedOrderID>21-07829-62837</ExtendedOrderID>
+                    <eBayPlusTransaction>false</eBayPlusTransaction>
+                    <GuaranteedShipping>false</GuaranteedShipping>
+                    <GuaranteedDelivery>false</GuaranteedDelivery>
+                </Transaction>
+            </TransactionArray>
+            <BuyerUserID>thop-5873</BuyerUserID>
+            <PaidTime>2021-11-07T01:47:38.803Z</PaidTime>
+            <IntegratedMerchantCreditCardEnabled>false</IntegratedMerchantCreditCardEnabled>
+            <EIASToken>nY+sHZ2PrBmdj6wVnY+sEZ2PrA2dj6MFloejDpCHog2dj6x9nY+seQ==</EIASToken>
+            <PaymentHoldStatus>None</PaymentHoldStatus>
+            <IsMultiLegShipping>false</IsMultiLegShipping>
+            <MonetaryDetails>
+                <Payments>
+                    <Payment>
+                        <PaymentStatus>Succeeded</PaymentStatus>
+                        <Payer type="eBayUser">thop-5873</Payer>
+                        <Payee type="eBayUser">threeriverssupply</Payee>
+                        <PaymentTime>2021-11-07T01:47:38.803Z</PaymentTime>
+                        <PaymentAmount currencyID="USD">322.11</PaymentAmount>
+                        <ReferenceID type="ExternalTransactionID">936735917901</ReferenceID>
+                    </Payment>
+                </Payments>
+                <Refunds>
+                    <Refund>
+                        <RefundStatus>Succeeded</RefundStatus>
+                        <RefundType>PaymentRefund</RefundType>
+                        <RefundTo type="eBayUser">thop-5873</RefundTo>
+                        <RefundTime>2021-11-07T02:34:48.803Z</RefundTime>
+                        <RefundAmount currencyID="USD">-284.42</RefundAmount>
+                        <ReferenceID type="ExternalTransactionID">5263178604</ReferenceID>
+                    </Refund>
+                </Refunds>
+            </MonetaryDetails>
+            <SellerUserID>threeriverssupply</SellerUserID>
+            <SellerEIASToken>nY+sHZ2PrBmdj6wVnY+sEZ2PrA2dj6AFl4SpCpKBogydj6x9nY+seQ==</SellerEIASToken>
+            <CancelReason>BuyerAskedCancel</CancelReason>
+            <CancelStatus>CancelClosedWithRefund</CancelStatus>
+            <ExtendedOrderID>21-07829-62837</ExtendedOrderID>
+            <ContainseBayPlusTransaction>false</ContainseBayPlusTransaction>
+        </Order>
+    </OrderArray>
+</GetOrdersResponse>

--- a/src/EbayAccessTests/Misc/ExtensionsTests.cs
+++ b/src/EbayAccessTests/Misc/ExtensionsTests.cs
@@ -14,7 +14,7 @@ using Item = EbayAccess.Models.ReviseFixedPriceItemResponse.Item;
 namespace EbayAccessTests.Misc
 {
 	[ TestFixture ]
-	public class Extensions
+	public class ExtensionsTests
 	{
 		/// <summary>
 		/// Ebay accepts format: YYYY-MM-DDTHH:MM:SS.SSSZ
@@ -330,6 +330,15 @@ namespace EbayAccessTests.Misc
 			var truncatedBody = body.LimitBodyLogSize();
 
 			truncatedBody.Length.Should().Be( EbayAccess.Misc.Extensions.MaxBodyLogSize );
+		}
+
+		[ TestCase( null ) ]
+		[ TestCase( "" ) ]
+		public void ToIntOrDefault_ShouldReturnDefault_WhenSourceIsEmpty( string source )
+		{
+			var result = source.ToIntOrDefault();
+
+			result.Should().Be( default );
 		}
 	}
 }

--- a/src/EbayAccessTests/Models/GetOrdersResponse/OrderExtendedTests.cs
+++ b/src/EbayAccessTests/Models/GetOrdersResponse/OrderExtendedTests.cs
@@ -1,0 +1,25 @@
+﻿using EbayAccess.Models.GetOrdersResponse;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EbayAccessTests.Models.GetOrdersResponse
+{
+	public class OrderExtendedTests
+	{
+		[ Test ]
+		public void GetOrderId_ShouldReturnNull_WhenSalesRecordNumberIsDefault_andUseSellingManagerRecordNumberInsteadIsTrue()
+		{
+			var order = new Order
+			{
+				ShippingDetails = new ShippingDetails
+				{
+					SellingManagerSalesRecordNumber = default
+				}
+			};
+
+			var result = order.GetOrderId( useSellingManagerRecordNumberInstead: true );
+
+			result.Should().BeNull();
+		}
+	}
+}

--- a/src/EbayAccessTests/Services/Parsers/EbayGetOrdersResponseParserTest.cs
+++ b/src/EbayAccessTests/Services/Parsers/EbayGetOrdersResponseParserTest.cs
@@ -172,5 +172,17 @@ namespace EbayAccessTests.Services.Parsers
 				transaction.TotalTaxAmountCurrencyId.ToString().Should().Be( "AUD" );
 			}
 		}
+
+		[ Test ]
+		public void Parse_GetOrdersResponse_ShouldReturnDefaultSalesRecordNumber_WhenSalesRecordNumberIsMissing()
+		{
+			using( var fs = new FileStream( @".\Files\GetOrdersResponse\EbayServiceGetOrdersResponseWithoutSellingManagerSalesRecordNumber.xml", FileMode.Open, FileAccess.Read ) )
+			{
+				var orders = new EbayGetOrdersResponseParser().Parse( fs );
+
+				var order = orders.Orders.Single();
+				order.ShippingDetails.SellingManagerSalesRecordNumber.Should().Be( default( int ) );
+			}
+		}
 	}
 }

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.10.0.0" ) ]
+[ assembly : AssemblyVersion( "1.11.0.0" ) ]


### PR DESCRIPTION
[GUARD-2893]

### Background
eBay returns some orders (have only seen Cancelled) without SellingManagerSalesRecordNumber under ShippingDetails. Based on the eBay API docs this field is optional, but we don't fall under the specific cases when it's not returned. We have to handle this case

### Fix Details

- GetOrdersResponseParser: When Order.ShippingDetails.SellingManagerSalesRecordNumber is missing from the response, deserialize without throwing and return orderId as null
- Add tests that validate the fix
- Refactor: Add Rider folders to .gitignore
- Refactor: Use MSBuild 16 in order to use modern C# features

# Type of change <!-- should only be one -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Functionality change (fix or feature that would cause existing functionality to work differently than before)
- [ ] Configuration change
- [ ] New / updated script
- [ ] Refactoring
- [ ] New tests to existing code

# PR Readiness Checklist

<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [x] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [ ] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-2893]: https://agileharbor.atlassian.net/browse/GUARD-2893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ