### PR TITLE
GUARD-2952 (Access Final) Remove -alpha

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -100,7 +100,7 @@ task NuGet Package, Version, {
 <package>
 	<metadata>
 		<id>$project_name</id>
-		<version>$Version-alpha</version>
+		<version>$Version</version>
 		<authors>SkuVault</authors>
 		<owners>SkuVault</owners>
 		<projectUrl>https://github.com/agileharbor/$project_name</projectUrl>


### PR DESCRIPTION
[GUARD-2952]

Summary: Get the package ready for release.

#### Background
A long time ago, in a galaxy far away packages wanted to break free from being ostracized as "-alphas" ;)

#### About these changes
Remove "-alpha" from package version, now that it's been tested in QA and is ready for release

### PR Readiness Checklist
<!-- Complete all the checklist steps to the best of your ability, marking steps as you complete them or adding comment on why you didn't do it. -->

- [ ] I have updated all relevant configuration
- [x] Followed [development conventions][1] to the best of my ability
- [x] Code is documented, particularly public interfaces and hard-to-understand areas
- [ ] Tests are updated / added and all pass
- [x] Performed a self-review of my own code
- [x] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [ ] Confluence documentation is updated, if needed
- [x] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[GUARD-2952]: https://agileharbor.atlassian.net/browse/GUARD-2952?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ