### PR TITLE
VT-6451 Ebay: Intermittent errors on the Inventory Syncs

### DIFF
--- a/src/EbayAccess/EbayService.cs
+++ b/src/EbayAccess/EbayService.cs
@@ -438,7 +438,9 @@ namespace EbayAccess
 							EbayErrors.ReplaceableValue,
 							EbayErrors.MpnHasAnInvalidValue,
 							EbayErrors.DuplicateListingPolicy,
-							EbayErrors.OperationIsNotAllowedForInventoryItems
+							EbayErrors.OperationIsNotAllowedForInventoryItems,
+							EbayErrors.InvalidMultiSkuItemId,
+							EbayErrors.AuctionEnded
 						} );
 
 					if( res.Errors == null || !res.Errors.Any() )

--- a/src/EbayAccess/Models/EbayErrors.cs
+++ b/src/EbayAccess/Models/EbayErrors.cs
@@ -4,199 +4,145 @@ namespace EbayAccess.Models
 {
 	public static class EbayErrors
 	{
-		public static ResponseError EbayPixelSizeError
-		{
-			get
-			{
-				return new ResponseError
-				{
-					ErrorCode = "21919137",
-					LongMessage = "Buyers love large photos that clearly show the item, so please upload high-resolution photos that are at least 500 pixels on the longest side",
-					ShortMessage = "Buyers love large photos that clearly show the item, so please upload high-resolution photos that are at least 500 pixels on the longest side",
-					SeverityCode = "Error"
-				};
-			}
-		}
+		public const string EbayPixelSizeErrorCode = "21919137";
+		public const string ItemConditionRequiredErrorCode = "21916884";
+		public const string DuplicateCustomVariationLabelErrorCode = "21916585";
+		public const string LvisBlockedErrorCode = "21916293";
+		public const string UnsupportedListingTypeErrorCode = "21916286";
+		public const string RequestedUserIsSuspendedErrorCode = "841";
+		public const string InternalErrorToTheApplicationErrorCode = "10007";
+		public const string ReplaceableValueErrorCode = "21919188";
+		public const string VariationLevelSKUAndItemIDShouldBeSuppliedErrorCode = "21916735";
+		public const string MpnHasAnInvalidValueErrorCode = "21919302";
+		public const string DuplicateListingPolicyErrorCode = "21919067";
+		public const string OperationIsNotAllowedForInventoryItemsErrorCode = "21919474";
+		public const string InvalidMultiSkuItemIdErrorCode = "21916635";
+		public const string AuctionEndedErrorCode = "291";
 
-		public static ResponseError ItemConditionRequired
-		{
-			get
+		public static ResponseError EbayPixelSizeError =>
+			new ResponseError
 			{
-				return new ResponseError
-				{
-					ErrorCode = "21916884",
-					LongMessage = "Condition is required for this category.",
-					ShortMessage = "Item condition required",
-					SeverityCode = "Error"
-				};
-			}
-		}
+				ErrorCode = EbayPixelSizeErrorCode,
+				LongMessage = "Buyers love large photos that clearly show the item, so please upload high-resolution photos that are at least 500 pixels on the longest side",
+				ShortMessage = "Buyers love large photos that clearly show the item, so please upload high-resolution photos that are at least 500 pixels on the longest side",
+				SeverityCode = "Error"
+			};
 
-		public static ResponseError DuplicateCustomVariationLabel
-		{
-			get
+		public static ResponseError ItemConditionRequired =>
+			new ResponseError
 			{
-				return new ResponseError
-				{
-					ErrorCode = "21916585",
-					LongMessage = "Duplicate custom variation label",
-					ShortMessage = "Duplicate custom variation label",
-					SeverityCode = "Error"
-				};
-			}
-		}
+				ErrorCode = ItemConditionRequiredErrorCode,
+				LongMessage = "Condition is required for this category.",
+				ShortMessage = "Item condition required",
+				SeverityCode = "Error"
+			};
 
-		public static ResponseError LvisBlockedError
-		{
-			get
+		public static ResponseError DuplicateCustomVariationLabel =>
+			new ResponseError
 			{
-				return new ResponseError
-				{
-					ErrorCode = "21916293",
-					LongMessage = "Lvis validation blocked",
-					ShortMessage = "Lvis blocked",
-					SeverityCode = "Error"
-				};
-			}
-		}
+				ErrorCode = DuplicateCustomVariationLabelErrorCode,
+				LongMessage = "Duplicate custom variation label",
+				ShortMessage = "Duplicate custom variation label",
+				SeverityCode = "Error"
+			};
 
-		public static ResponseError UnsupportedListingType
-		{
-			get
+		public static ResponseError LvisBlockedError =>
+			new ResponseError
 			{
-				return new ResponseError
-				{
-					ErrorCode = "21916286",
-					LongMessage = "Valid Listing type for fixedprice apis are FixedPriceItem and StoresFixedPrice.",
-					ShortMessage = "Unsupported ListingType",
-					SeverityCode = "Error"
-				};
-			}
-		}
+				ErrorCode = LvisBlockedErrorCode,
+				LongMessage = "Lvis validation blocked",
+				ShortMessage = "Lvis blocked",
+				SeverityCode = "Error"
+			};
 
-		public static ResponseError RequestedUserIsSuspended
-		{
-			get
+		public static ResponseError UnsupportedListingType =>
+			new ResponseError
 			{
-				return new ResponseError
-				{
-					ErrorCode = "841",
-					LongMessage = "The account for user ID \"replaceable_value\" specified in this request is suspended. Sorry, you can only request information for current users.",
-					ShortMessage = "Requested user is suspended",
-					SeverityCode = "Error"
-				};
-			}
-		}
-		public static ResponseError InternalErrorToTheApplication
-		{
-			get
-			{
-				return new ResponseError
-				{
-					ErrorCode = "10007",
-					LongMessage = "Internal error to the application",
-					ShortMessage = "Internal error to the application",
-					SeverityCode = "Error"
-				};
-			}
-		}
+				ErrorCode = UnsupportedListingTypeErrorCode,
+				LongMessage = "Valid Listing type for fixedprice apis are FixedPriceItem and StoresFixedPrice.",
+				ShortMessage = "Unsupported ListingType",
+				SeverityCode = "Error"
+			};
 
-		public static ResponseError ReplaceableValue
-		{
-			get
+		public static ResponseError RequestedUserIsSuspended =>
+			new ResponseError
 			{
-				return new ResponseError
-				{
-					ErrorCode = "21919188",
-					LongMessage = "replaceable_value",
-					ShortMessage = "replaceable_value",
-					SeverityCode = "Error"
-				};
-			}
-		}
+				ErrorCode = RequestedUserIsSuspendedErrorCode,
+				LongMessage = "The account for user ID \"replaceable_value\" specified in this request is suspended. Sorry, you can only request information for current users.",
+				ShortMessage = "Requested user is suspended",
+				SeverityCode = "Error"
+			};
 
-		public static ResponseError VariationLevelSKUAndItemIDShouldBeSupplied
-		{
-			get
+		public static ResponseError InternalErrorToTheApplication =>
+			new ResponseError
 			{
-				return new ResponseError
-				{
-					ErrorCode = "21916735",
-					LongMessage = "Variation level SKU or Variation level SKU and ItemID should be supplied to revise a Multi-SKU item.",
-					ShortMessage = "Cannot revise a Multi-SKU item when item level SKU is supplied.",
-					SeverityCode = "Error"
-				};
-			}
-		}
+				ErrorCode = InternalErrorToTheApplicationErrorCode,
+				LongMessage = "Internal error to the application",
+				ShortMessage = "Internal error to the application",
+				SeverityCode = "Error"
+			};
 
-		public static ResponseError MpnHasAnInvalidValue
-		{
-			get
+		public static ResponseError ReplaceableValue =>
+			new ResponseError
 			{
-				return new ResponseError
-				{
-					ErrorCode = "21919302",
-					LongMessage = "MPN has an invalid value of \"replaceable_value\". Enter a valid value and try again.",
-					ShortMessage = "MPN has an invalid value of \"replaceable_value\".",
-					SeverityCode = "Error"
-				};
-			}
-		}
+				ErrorCode = ReplaceableValueErrorCode,
+				LongMessage = "replaceable_value",
+				ShortMessage = "replaceable_value",
+				SeverityCode = "Error"
+			};
 
-		public static ResponseError DuplicateListingPolicy
-		{
-			get
+		public static ResponseError VariationLevelSKUAndItemIDShouldBeSupplied =>
+			new ResponseError
 			{
-				return new ResponseError
-				{
-					ErrorCode = "21919067",
-					LongMessage = "It looks like this listing is for an item you already have on eBay: \"replaceable_value\",  (\"replaceable_value\"). We don't allow listings for identical items from the same seller to appear on eBay at the same time. If you'd like to list more than one of the same item, create a multi-quantity fixed price listing.",
-					ShortMessage = "Listing violates the Duplicate Listing policy.",
-					SeverityCode = "Error"
-				};
-			}
-		}
+				ErrorCode = VariationLevelSKUAndItemIDShouldBeSuppliedErrorCode,
+				LongMessage = "Variation level SKU or Variation level SKU and ItemID should be supplied to revise a Multi-SKU item.",
+				ShortMessage = "Cannot revise a Multi-SKU item when item level SKU is supplied.",
+				SeverityCode = "Error"
+			};
 
-		public static ResponseError OperationIsNotAllowedForInventoryItems
-		{
-			get
+		public static ResponseError MpnHasAnInvalidValue =>
+			new ResponseError
 			{
-				return new ResponseError
-				{
-					ErrorCode = "21919474",
-					LongMessage = "Inventory-based listing management is not currently supported by this tool. Please refer to the tool used to create this listing.",
-					ShortMessage = "This operation is not allowed for inventory items.",
-					SeverityCode = "Error"
-				};
-			}
-		}
+				ErrorCode = MpnHasAnInvalidValueErrorCode,
+				LongMessage = "MPN has an invalid value of \"replaceable_value\". Enter a valid value and try again.",
+				ShortMessage = "MPN has an invalid value of \"replaceable_value\".",
+				SeverityCode = "Error"
+			};
 
-		public static ResponseError InvalidMultiSkuItemId
-		{
-			get
+		public static ResponseError DuplicateListingPolicy =>
+			new ResponseError
 			{
-				return new ResponseError
-				{
-					ErrorCode = "21916635",
-					LongMessage = "Invalid Multi-SKU item id supplied with variations.",
-					ShortMessage = "Invalid Multi-SKU item id.",
-					SeverityCode = "Error"
-				};
-			}
-		}
+				ErrorCode = DuplicateListingPolicyErrorCode,
+				LongMessage = "It looks like this listing is for an item you already have on eBay: \"replaceable_value\",  (\"replaceable_value\"). We don't allow listings for identical items from the same seller to appear on eBay at the same time. If you'd like to list more than one of the same item, create a multi-quantity fixed price listing.",
+				ShortMessage = "Listing violates the Duplicate Listing policy.",
+				SeverityCode = "Error"
+			};
 
-		public static ResponseError AuctionEnded
-		{
-			get
+		public static ResponseError OperationIsNotAllowedForInventoryItems =>
+			new ResponseError
 			{
-				return new ResponseError
-				{
-					ErrorCode = "291",
-					LongMessage = "You are not allowed to revise ended listings.",
-					ShortMessage = "Auction ended.",
-					SeverityCode = "Error"
-				};
-			}
-		}
+				ErrorCode = OperationIsNotAllowedForInventoryItemsErrorCode,
+				LongMessage = "Inventory-based listing management is not currently supported by this tool. Please refer to the tool used to create this listing.",
+				ShortMessage = "This operation is not allowed for inventory items.",
+				SeverityCode = "Error"
+			};
+
+		public static ResponseError InvalidMultiSkuItemId =>
+			new ResponseError
+			{
+				ErrorCode = InvalidMultiSkuItemIdErrorCode,
+				LongMessage = "Invalid Multi-SKU item id supplied with variations.",
+				ShortMessage = "Invalid Multi-SKU item id.",
+				SeverityCode = "Error"
+			};
+
+		public static ResponseError AuctionEnded =>
+			new ResponseError
+			{
+				ErrorCode = AuctionEndedErrorCode,
+				LongMessage = "You are not allowed to revise ended listings.",
+				ShortMessage = "Auction ended.",
+				SeverityCode = "Error"
+			};
 	}
 }

--- a/src/EbayAccess/Models/EbayErrors.cs
+++ b/src/EbayAccess/Models/EbayErrors.cs
@@ -170,5 +170,33 @@ namespace EbayAccess.Models
 				};
 			}
 		}
+
+		public static ResponseError InvalidMultiSkuItemId
+		{
+			get
+			{
+				return new ResponseError
+				{
+					ErrorCode = "21916635",
+					LongMessage = "Invalid Multi-SKU item id supplied with variations.",
+					ShortMessage = "Invalid Multi-SKU item id.",
+					SeverityCode = "Error"
+				};
+			}
+		}
+
+		public static ResponseError AuctionEnded
+		{
+			get
+			{
+				return new ResponseError
+				{
+					ErrorCode = "291",
+					LongMessage = "You are not allowed to revise ended listings.",
+					ShortMessage = "Auction ended.",
+					SeverityCode = "Error"
+				};
+			}
+		}
 	}
 }

--- a/src/EbayAccessTests/EbayAccessTests.csproj
+++ b/src/EbayAccessTests/EbayAccessTests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="..\Global\GlobalAssemblyInfo.cs">
       <Link>Properties\GlobalAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="EbayBaseResponseTest.cs" />
     <Compile Include="EbayServiceTest.cs" />
     <Compile Include="Misc\ExtensionsTests.cs" />
     <Compile Include="Misc\LoggerTests.cs" />

--- a/src/EbayAccessTests/EbayAccessTests.csproj
+++ b/src/EbayAccessTests/EbayAccessTests.csproj
@@ -13,6 +13,7 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/src/EbayAccessTests/EbayBaseResponseTest.cs
+++ b/src/EbayAccessTests/EbayBaseResponseTest.cs
@@ -15,8 +15,8 @@ namespace EbayAccessTests
 			EbayErrors.InvalidMultiSkuItemId
 		};
 
-		[ TestCase( EbayErrors.InvalidMultiSkuItemIdErrorCode ) ]
-		public void SkipErrorsAndDo_ReturnResponseWithoutIgnoredErrors( string errorCode )
+		[ Test ]
+		public void SkipErrorsAndDo_ErrorDoesNotRemainInResponse_WhenErrorIsIgnored()
 		{
 			// Arrange
 			var response = new EbayBaseResponse
@@ -25,7 +25,7 @@ namespace EbayAccessTests
 				{
 					new ResponseError
 					{
-						ErrorCode = errorCode
+						ErrorCode = EbayErrors.InvalidMultiSkuItemIdErrorCode
 					}
 				}
 			};
@@ -34,18 +34,11 @@ namespace EbayAccessTests
 			response.SkipErrorsAndDo( null, this._errorsForIgnoring );
 
 			// Assert
-			response.Errors.Any( x => x.ErrorCode.Equals( errorCode ) ).Should().BeFalse();
+			response.Errors.Any( x => x.ErrorCode.Equals( EbayErrors.InvalidMultiSkuItemIdErrorCode ) ).Should().BeFalse();
 		}
 
-		[ TestCase( EbayErrors.EbayPixelSizeErrorCode ) ]
-		[ TestCase( EbayErrors.LvisBlockedErrorCode ) ]
-		[ TestCase( EbayErrors.UnsupportedListingTypeErrorCode ) ]
-		[ TestCase( EbayErrors.ReplaceableValueErrorCode ) ]
-		[ TestCase( EbayErrors.MpnHasAnInvalidValueErrorCode ) ]
-		[ TestCase( EbayErrors.DuplicateListingPolicyErrorCode ) ]
-		[ TestCase( EbayErrors.OperationIsNotAllowedForInventoryItemsErrorCode ) ]
-		[ TestCase( EbayErrors.AuctionEndedErrorCode ) ]
-		public void SkipErrorsAndDo_Throws_WhenErrorIsNotIgnored( string errorCode )
+		[ Test ]
+		public void SkipErrorsAndDo_ErrorRemainsInResponse_WhenErrorIsNotIgnored()
 		{
 			// Arrange
 			var response = new EbayBaseResponse
@@ -54,7 +47,7 @@ namespace EbayAccessTests
 				{
 					new ResponseError
 					{
-						ErrorCode = errorCode
+						ErrorCode = EbayErrors.EbayPixelSizeErrorCode
 					}
 				}
 			};
@@ -63,7 +56,7 @@ namespace EbayAccessTests
 			response.SkipErrorsAndDo( null, this._errorsForIgnoring );
 
 			// Assert
-			response.Errors.Any( x => x.ErrorCode.Equals( errorCode ) ).Should().BeTrue();
+			response.Errors.Any( x => x.ErrorCode.Equals( EbayErrors.EbayPixelSizeErrorCode ) ).Should().BeTrue();
 		}
 	}
 }

--- a/src/EbayAccessTests/EbayBaseResponseTest.cs
+++ b/src/EbayAccessTests/EbayBaseResponseTest.cs
@@ -10,29 +10,13 @@ namespace EbayAccessTests
 	[ TestFixture ]
 	public class EbayBaseResponseTest
 	{
-		private readonly List< ResponseError > _errorsForIgnoring = new List< ResponseError >
+		private readonly List< ResponseError > _errorsForIgnoring = new()
 		{
-			EbayErrors.EbayPixelSizeError,
-			EbayErrors.LvisBlockedError,
-			EbayErrors.UnsupportedListingType,
-			EbayErrors.ReplaceableValue,
-			EbayErrors.MpnHasAnInvalidValue,
-			EbayErrors.DuplicateListingPolicy,
-			EbayErrors.OperationIsNotAllowedForInventoryItems,
-			EbayErrors.InvalidMultiSkuItemId,
-			EbayErrors.AuctionEnded
+			EbayErrors.InvalidMultiSkuItemId
 		};
 
-		[ TestCase( EbayErrors.EbayPixelSizeErrorCode ) ]
-		[ TestCase( EbayErrors.LvisBlockedErrorCode ) ]
-		[ TestCase( EbayErrors.UnsupportedListingTypeErrorCode ) ]
-		[ TestCase( EbayErrors.ReplaceableValueErrorCode ) ]
-		[ TestCase( EbayErrors.MpnHasAnInvalidValueErrorCode ) ]
-		[ TestCase( EbayErrors.DuplicateListingPolicyErrorCode ) ]
-		[ TestCase( EbayErrors.OperationIsNotAllowedForInventoryItemsErrorCode ) ]
 		[ TestCase( EbayErrors.InvalidMultiSkuItemIdErrorCode ) ]
-		[ TestCase( EbayErrors.AuctionEndedErrorCode ) ]
-		public void SkipErrorsAndDo_ReturnResponseWithoutIgnoringErrors( string errorCode )
+		public void SkipErrorsAndDo_ReturnResponseWithoutIgnoredErrors( string errorCode )
 		{
 			// Arrange
 			var response = new EbayBaseResponse
@@ -51,6 +35,35 @@ namespace EbayAccessTests
 
 			// Assert
 			response.Errors.Any( x => x.ErrorCode.Equals( errorCode ) ).Should().BeFalse();
+		}
+
+		[ TestCase( EbayErrors.EbayPixelSizeErrorCode ) ]
+		[ TestCase( EbayErrors.LvisBlockedErrorCode ) ]
+		[ TestCase( EbayErrors.UnsupportedListingTypeErrorCode ) ]
+		[ TestCase( EbayErrors.ReplaceableValueErrorCode ) ]
+		[ TestCase( EbayErrors.MpnHasAnInvalidValueErrorCode ) ]
+		[ TestCase( EbayErrors.DuplicateListingPolicyErrorCode ) ]
+		[ TestCase( EbayErrors.OperationIsNotAllowedForInventoryItemsErrorCode ) ]
+		[ TestCase( EbayErrors.AuctionEndedErrorCode ) ]
+		public void SkipErrorsAndDo_Throws_WhenErrorIsNotIgnored( string errorCode )
+		{
+			// Arrange
+			var response = new EbayBaseResponse
+			{
+				Errors = new[]
+				{
+					new ResponseError
+					{
+						ErrorCode = errorCode
+					}
+				}
+			};
+
+			// Act
+			response.SkipErrorsAndDo( null, this._errorsForIgnoring );
+
+			// Assert
+			response.Errors.Any( x => x.ErrorCode.Equals( errorCode ) ).Should().BeTrue();
 		}
 	}
 }

--- a/src/EbayAccessTests/EbayBaseResponseTest.cs
+++ b/src/EbayAccessTests/EbayBaseResponseTest.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using EbayAccess.Models;
+using EbayAccess.Models.BaseResponse;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace EbayAccessTests
+{
+	[ TestFixture ]
+	public class EbayBaseResponseTest
+	{
+		private readonly List< ResponseError > _errorsForIgnoring = new List< ResponseError >
+		{
+			EbayErrors.EbayPixelSizeError,
+			EbayErrors.LvisBlockedError,
+			EbayErrors.UnsupportedListingType,
+			EbayErrors.ReplaceableValue,
+			EbayErrors.MpnHasAnInvalidValue,
+			EbayErrors.DuplicateListingPolicy,
+			EbayErrors.OperationIsNotAllowedForInventoryItems,
+			EbayErrors.InvalidMultiSkuItemId,
+			EbayErrors.AuctionEnded
+		};
+
+		[ TestCase( EbayErrors.EbayPixelSizeErrorCode ) ]
+		[ TestCase( EbayErrors.LvisBlockedErrorCode ) ]
+		[ TestCase( EbayErrors.UnsupportedListingTypeErrorCode ) ]
+		[ TestCase( EbayErrors.ReplaceableValueErrorCode ) ]
+		[ TestCase( EbayErrors.MpnHasAnInvalidValueErrorCode ) ]
+		[ TestCase( EbayErrors.DuplicateListingPolicyErrorCode ) ]
+		[ TestCase( EbayErrors.OperationIsNotAllowedForInventoryItemsErrorCode ) ]
+		[ TestCase( EbayErrors.InvalidMultiSkuItemIdErrorCode ) ]
+		[ TestCase( EbayErrors.AuctionEndedErrorCode ) ]
+		public void SkipErrorsAndDo_ReturnResponseWithoutIgnoringErrors( string errorCode )
+		{
+			// Arrange
+			var response = new EbayBaseResponse
+			{
+				Errors = new[]
+				{
+					new ResponseError
+					{
+						ErrorCode = errorCode
+					}
+				}
+			};
+
+			// Act
+			response.SkipErrorsAndDo( null, this._errorsForIgnoring );
+
+			// Assert
+			response.Errors.Any( x => x.ErrorCode.Equals( errorCode ) ).Should().BeFalse();
+		}
+	}
+}

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -22,4 +22,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[ assembly : AssemblyVersion( "1.14.1.0" ) ]
+[ assembly : AssemblyVersion( "1.15.0.0" ) ]


### PR DESCRIPTION
# Description

Tickets: [VT-6451]

Summary: some errors fails inventory/full inventory sync

## Background

We have some errors for several SKUs and we throw exception - after that our sync will fail and other SKUs will not sync.

## About these changes

After investigation and discussion we decided ignore these errors, because looks like it relates to settings on side Ebay. In any case we will log these cases. eBayAccess already ignore some errors so I just add new to this code.

# PR Readiness Checklist

- [X] I have updated all relevant configuration
- [X] Followed [development conventions][1] to the best of my ability
- [X] Code is documented, particularly public interfaces and hard-to-understand areas
- [X] Tests are updated / added and all pass
- [X] Performed a self-review of my own code
- [X] Acceptance criterias are confirmed by testing changes in UI (or another appropriate way)
- [X] Confluence documentation is updated, if needed
- [X] New code does not generate new warnings

[1]: https://agileharbor.atlassian.net/wiki/spaces/DEV/pages/1114130/Conventions


[VT-6451]: https://agileharbor.atlassian.net/browse/VT-6451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ